### PR TITLE
Release/4.28

### DIFF
--- a/charts/opc-router/Chart.yaml
+++ b/charts/opc-router/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "4.27"
+appVersion: "4.28"
 
 dependencies:
  - name: mongodb

--- a/charts/opc-router/templates/_helpers.tpl
+++ b/charts/opc-router/templates/_helpers.tpl
@@ -27,6 +27,10 @@ If release name contains chart name it will be used as a full name.
 {{- include "opc-router.fullname" . | cat "redundant" | replace " " "-" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "opc-router.license.fullname" -}}
+{{- include "opc-router.fullname" . | cat "license" | replace " " "-" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/charts/opc-router/templates/deployment.yaml
+++ b/charts/opc-router/templates/deployment.yaml
@@ -83,10 +83,13 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          # Volume mount for license
+          volumeMounts:
+          - mountPath: /root/.dotnet/corefx/cryptography/x509stores/
+            name: license-volume
       {{- if .Values.project.projectRepo }}
       # Project repo is specified: Get and load project
       # Volume mount for the project and configuration file
-          volumeMounts:
           - mountPath: /data
             name: project-volume
           # Command and arguments for loading the project and configuration into the opcrouter
@@ -152,8 +155,13 @@ spec:
               name: {{ .Values.project.auth.ssh_secret | default (printf "%s-%s" (include "opc-router.fullname" $) "secret" | trunc 63 | trimSuffix "-") }}
               key: project-ssh-key
         {{- end }}
+      {{- end }}
       # Volume for the project and configuration file
       volumes:
+      - name: license-volume
+        persistentVolumeClaim:
+          claimName: {{ include "opc-router.license.fullname" . }}
+      {{- if .Values.project.projectRepo }}
       - name: project-volume
       {{- if .Values.project.persistantVolume.deploy }}
         persistentVolumeClaim:

--- a/charts/opc-router/templates/licenseclaim.yaml
+++ b/charts/opc-router/templates/licenseclaim.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "opc-router.license.fullname" . }}
+  labels:
+    {{- include "opc-router.labels" . | nindent 4 }}
+  {{- if .Values.license.keepAfterUninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
+spec:
+  {{- with .Values.license.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.license.capacity }}

--- a/charts/opc-router/templates/licensestorage.yaml
+++ b/charts/opc-router/templates/licensestorage.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.license.storageVolume.createVolume }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "opc-router.license.fullname" . }}
+  labels:
+    type: local
+    {{- include "opc-router.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.license.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+  capacity: 
+    storage: {{ .Values.license.capacity }}
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: {{ .Values.license.storageVolume.reclaimPolicy }}
+  {{ .Values.license.storageVolume.volumeType }}:
+  {{- with .Values.license.storageVolume.volumeTypeOptions }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  claimRef:
+    name: {{ include "opc-router.license.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- with .Values.license.storageVolume.nodeAffinity }}
+  nodeAffinity:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/opc-router/templates/persistantclaim.yaml
+++ b/charts/opc-router/templates/persistantclaim.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.project.persistantVolume.deploy }}
+{{- if .Values.project.projectRepo }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -12,4 +13,5 @@ spec:
   resources:
     requests:
       storage: {{ .Values.project.persistantVolume.size }}
+{{- end }}
 {{- end }}

--- a/charts/opc-router/templates/persistantstorage.yaml
+++ b/charts/opc-router/templates/persistantstorage.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.project.persistantVolume.deploy }}
+{{- if .Values.project.projectRepo }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -17,4 +18,5 @@ spec:
   claimRef:
     name: {{ include "opc-router.fullname" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/opc-router/templates/service.yaml
+++ b/charts/opc-router/templates/service.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "opc-router.fullname" . }}
   labels:
     {{- include "opc-router.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/opc-router/values.yaml
+++ b/charts/opc-router/values.yaml
@@ -101,7 +101,7 @@ license:
   # If left as empty, will use default storage class, when availible.
   storageClassName:
   # If true, the license volume claim and volume will persist even after uninstalling the chart.
-  keepAfterUninstall: true
+  keepAfterUninstall: false
   storageVolume:
     # If true, a new persistant volume is created for the license using the settings provided here.
     # When false, dynamic provisioning might still create a volume using the setting specified by the storageClass. 

--- a/charts/opc-router/values.yaml
+++ b/charts/opc-router/values.yaml
@@ -9,7 +9,7 @@ image:
   repository: opcrouter/service
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 4.27
+  tag:
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/opc-router/values.yaml
+++ b/charts/opc-router/values.yaml
@@ -83,13 +83,40 @@ service:
   # When list left blank, NodePort will chose a random port itself.
   # nodePort need to be in range 30000 to 32768.
   nodePort:
-  # External IPs. The serice will be reachable under these IPs from outside the cluser,
+  # External IPs. The service will be reachable under these IPs from outside the cluser,
   # when traffic ingresses into the cluster with the IPs as destination.
   externalIPs: []
   # LoadBalancer IP. Only used when LoadBalancer.
   # Used by some cloud providers to add external load balancers.
   # If not supported, it is just ignored.
   loadBalancerIP:
+  # Annotations for service. 
+  # Some cloud providers may need special annotations for their loadbalancers to work.
+  annotations: {}
+
+license:
+  # Storage capacity of license volume claim.
+  capacity: "100M"
+  # Storage class name of license volume claim.
+  # If left as empty, will use default storage class, when availible.
+  storageClassName:
+  # If true, the license volume claim and volume will persist even after uninstalling the chart.
+  keepAfterUninstall: true
+  storageVolume:
+    # If true, a new persistant volume is created for the license using the settings provided here.
+    # When false, dynamic provisioning might still create a volume using the setting specified by the storageClass. 
+    createVolume: false
+    # Persistant volume retain policy of license volume.
+    reclaimPolicy: Retain
+    # Volume type of license volume.
+    volumeType: local
+    # Volume type specific settings.
+    volumeTypeOptions: 
+      path: /license
+    # Mount options of license volume.
+    mountOptions: []
+    # Node affinity settings of license volume.
+    nodeAffinity: {}
 
 ingress:
   enabled: false


### PR DESCRIPTION
- Updated chart version to 0.1.4 and app version to 4.28
- Removed default image version tag override, so appVersion is used
- Added persistant storage for the opcrouter license and surrounding settings
- Added annotation setting for the service
- persistantclaim and persistant storage get only created when a project repo is configured