### PR TITLE
Feature/1.0.3/#329665 Fix issues #9 #10 #11

### DIFF
--- a/charts/opc-router/Chart.yaml
+++ b/charts/opc-router/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opc-router/templates/deployment.yaml
+++ b/charts/opc-router/templates/deployment.yaml
@@ -20,10 +20,8 @@ spec:
       labels:
         {{- include "opc-router.labels" . | nindent 8 }}
         {{- include "opc-router.originalSelectorLabels" . | nindent 8 }}
-        {{- if eq .Values.image.repository "opcrouter/runtime" }}
         {{- if not .Values.mongodb.deploy }}
         {{- include "opc-router.selectorLabels" . | nindent 8 }}
-        {{- end }}
         {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
@@ -49,12 +47,10 @@ spec:
               protocol: TCP
               name: web-management
             {{- end }}
-            {{- if eq .Values.image.repository "opcrouter/runtime" }}
             {{- if not .Values.mongodb.deploy }}
             - name: mongodb
               containerPort: 27017
               protocol: TCP
-            {{- end }}
             {{- end }}
           # Environment variables for the opcrouter container
           env:

--- a/charts/opc-router/templates/deployment.yaml
+++ b/charts/opc-router/templates/deployment.yaml
@@ -98,6 +98,10 @@ spec:
           - name: OR_IMPORT_RUNTIME_CONFIGURATION_FILE
             value: "/data/project/{{ .Values.project.configPath }}"
           {{- end }}
+          {{-  if .Values.ingress.enabled }}
+          - name: ASPNETCORE_FORWARDEDHEADERS_ENABLED
+            value: "true"
+          {{- end }}
           - name: OR_I_ACCEPT_EULA
             value: {{ .Values.I_do_accept_the_EULA | quote }}
           # Loading environment variables specified in the values file

--- a/charts/opc-router/values.yaml
+++ b/charts/opc-router/values.yaml
@@ -6,6 +6,8 @@ image:
   # Image for the opc router container
   # Has to be either "opcrouter/runtime" for the integrated database
   # or "opcrouter/service", which utilizes the external mongodb
+  # If using an image which uses an integrated mongodb like opcrouter/runtime, 
+  # it is required to set 'mongodb.deploy' to 'false' for the integrated mongodb to be used
   repository: opcrouter/service
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.


### PR DESCRIPTION
- Fix https://github.com/OPC-Router/helm-charts/issues/9  Remove behavior change based on specific opcrouter/runtime image repository
- Fix https://github.com/OPC-Router/helm-charts/issues/10 Automatically set ASPNETCORE_FORWARDEDHEADERS_ENABLED env var to true when using ingress
- Fix https://github.com/OPC-Router/helm-charts/issues/11 Added documentation regarding using the opcrouter/runtime image and ingress

Also fixed OPC Router naming pattern in README to be more consistent and updated chart version to 1.0.3